### PR TITLE
Backporting to ansible 2.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -323,12 +323,6 @@ octavia_container_interface: "{{ octavia_provider_network.container_interface }}
 octavia_ip_tables_fw: True
 # The iptable rules
 octavia_iptables_rules:
-  - # Allow icmp
-    chain: INPUT
-    protocol: icmp
-    ctstate: NEW
-    icmp_type: 8
-    jump: ACCEPT
   - # Allow existing connections:
     chain: INPUT
     in_interface: "{{ octavia_container_interface }}"

--- a/tasks/octavia_install.yml
+++ b/tasks/octavia_install.yml
@@ -33,14 +33,14 @@
       {% endfor %}
   when: octavia_developer_mode | bool
 
+# Modify so we get the Pike verison of Octavia
 - name: Install required pip packages
   pip:
-    name: "{{ octavia_requires_pip_packages }}"
+    name: "{{ octavia_requires_pip_packages | join(' ') }}"
     state: "{{ octavia_pip_package_state }}"
     extra_args: >-
       {{ octavia_developer_mode | ternary(pip_install_developer_constraints | default('--constraint /opt/developer-pip-constraints.txt'), '') }}
-      {{ (pip_install_upper_constraints is defined) | ternary('--constraint ' + pip_install_upper_constraints | default(''),'') }}
-      {{ pip_install_options | default('') }}
+      {{ pip_install_options + ' --isolated' | default('--isolated') }}
   register: install_packages
   until: install_packages|success
   retries: 5
@@ -84,16 +84,16 @@
     - octavia_get_venv | changed or octavia_venv_dir | changed
   notify: Restart octavia services
 
+# Modify so we get the Pike verison of Octavia
 - name: Install pip packages
   pip:
-    name: "{{ octavia_pip_packages }}"
+    name: "{{ octavia_pip_packages | join(' ') }}"
     state: "{{ octavia_pip_package_state }}"
     virtualenv: "{{ octavia_bin | dirname }}"
     virtualenv_site_packages: "no"
     extra_args: >-
       {{ octavia_developer_mode | ternary(pip_install_developer_constraints | default('--constraint /opt/developer-pip-constraints.txt'), '') }}
-      {{ (pip_install_upper_constraints is defined) | ternary('--constraint ' + pip_install_upper_constraints | default(''),'') }}
-      {{ pip_install_options | default('') }}
+      {{ pip_install_options + ' --isolated' | default('--isolated') }}
   register: install_packages
   until: install_packages|success
   retries: 5

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -20,3 +20,4 @@ octavia_distro_packages:
   - iptables-persistent
   - netfilter-persistent
   - libxml2-dev
+  - git


### PR DESCRIPTION
- make the pip install working with lack of list support
- remove the upper constraints and forces '--isolated' to build
  a Pike venv with the correct libraries